### PR TITLE
Fix synnax bug

### DIFF
--- a/src/limewire/limewire.py
+++ b/src/limewire/limewire.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from pprint import pprint
 
 import synnax as sy
 
@@ -106,7 +107,7 @@ async def write_data_to_synnax(
             ][0]
             data_to_write[message.get_index_channel()] = message.timestamp
             data_to_write[limewire_write_time_channel] = sy.TimeStamp.now()
-            print(data_to_write)
+            pprint(data_to_write, indent=4)
 
             if synnax_writer is None:
                 writer_channels = list(channels.keys()) + [

--- a/src/limewire/limewire.py
+++ b/src/limewire/limewire.py
@@ -120,7 +120,6 @@ async def write_data_to_synnax(
                 )
 
             synnax_writer.write(data_to_write)  # pyright: ignore[reportArgumentType]
-            synnax_writer.commit()
         except ValueError as err:
             print(f"{err}")
         finally:

--- a/src/limewire/limewire.py
+++ b/src/limewire/limewire.py
@@ -106,6 +106,7 @@ async def write_data_to_synnax(
             ][0]
             data_to_write[message.get_index_channel()] = message.timestamp
             data_to_write[limewire_write_time_channel] = sy.TimeStamp.now()
+            print(data_to_write)
 
             if synnax_writer is None:
                 writer_channels = list(channels.keys()) + [

--- a/src/limewire/limewire.py
+++ b/src/limewire/limewire.py
@@ -1,6 +1,5 @@
 import asyncio
 import time
-from pprint import pprint
 
 import synnax as sy
 
@@ -107,7 +106,6 @@ async def write_data_to_synnax(
             ][0]
             data_to_write[message.get_index_channel()] = message.timestamp
             data_to_write[limewire_write_time_channel] = sy.TimeStamp.now()
-            pprint(data_to_write, indent=4)
 
             if synnax_writer is None:
                 writer_channels = list(channels.keys()) + [


### PR DESCRIPTION
This PR fixes a bug in Synnax where the number of channels being written to didn't match the number of channels associated with a timestamp. I stopped calling `writer.commit()` since `enable_auto_commit` was set to `True`, and after I made that change, I didn't run into any further issues. I'm not 100% sure that was the root cause of the issue, but it seemed to fix the bug so I'm not complaining.