### PR TITLE
Set default flight computer address in Limewire

### DIFF
--- a/src/limewire/__main__.py
+++ b/src/limewire/__main__.py
@@ -8,10 +8,13 @@ from limewire.util import SocketAddress
 
 
 @click.command(context_settings={"help_option_names": ["--help", "-h"]})
-@click.argument("fc_address", type=SocketAddress())
+@click.argument(
+    "fc_address",
+    type=SocketAddress(),
+    default="141.212.192.170:5000",
+)
 def main(fc_address: tuple[str, int]):
     """Run Limewire."""
-
     limewire = Limewire()
 
     try:


### PR DESCRIPTION
This change sets the default flight computer socket address to `141.212.192.170:5000` for Limewire so it can be used without passing any arguments, which makes setting it up as a system service with NSSM easier. It still supports using a custom address for local testing purposes, so it shouldn't break any current workflows.